### PR TITLE
fix: force refetch product table after creation to ensure updated data

### DIFF
--- a/frontend/src/containers/Products/ProductTableContainer.tsx
+++ b/frontend/src/containers/Products/ProductTableContainer.tsx
@@ -12,7 +12,7 @@
  * @returns {JSX.Element} The product table container.
  */
 
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import { MoreHorizontal } from "lucide-react"
 import {
   DropdownMenu,
@@ -48,7 +48,11 @@ const ProductTableContainer: React.FC = () => {
   })
 
   // Fetch all products
-  const { data: products = [], isLoading, error } = useProducts()
+  const { data: products = [], isLoading, error, refetch } = useProducts()
+
+  useEffect(() => {
+    refetch()
+  }, [refetch])
 
   // Make priceGross a top-level property
   const transformedProducts = products.map((product) =>


### PR DESCRIPTION
Added a useEffect with refetch() on mount to ensure fresh data is always loaded when navigating to the product table.