### PR TITLE
Fix  invoice lineitems issue

### DIFF
--- a/frontend/src/components/invoice/InvoiceInformation.tsx
+++ b/frontend/src/components/invoice/InvoiceInformation.tsx
@@ -67,7 +67,7 @@ const InvoiceInformation: React.FC<InvoiceInformationProps> = ({ form }) => {
                   onChange={(e) => field.onChange(e.target.value)}
                   disabled={isLoadingCustomers}
                 >
-                  <option value="">None</option>
+                  {!field.value && <option value=""> </option>}
                   {customers.map((customer) => (
                     <option key={customer.id} value={customer.name}>
                       {customer.name}

--- a/frontend/src/components/invoice/InvoiceItems.tsx
+++ b/frontend/src/components/invoice/InvoiceItems.tsx
@@ -1,3 +1,9 @@
+/**
+ * @file InvoiceItems.tsx - Renders the dynamic invoice items table within the invoice creation form.
+ * It allows users to add, edit, and remove individual line items, including quantity, price, discount,
+ * tax code, and calculated amount. Product and tax data are synced from the backend.
+ */
+
 import React from "react"
 import { useFieldArray, UseFormReturn } from "react-hook-form"
 import { FormField, FormItem, FormControl } from "@/components/ui/form"

--- a/frontend/src/components/invoice/InvoiceItems.tsx
+++ b/frontend/src/components/invoice/InvoiceItems.tsx
@@ -132,8 +132,7 @@ const InvoiceItems: React.FC<InvoiceItemsProps> = ({ form }) => {
                                   )
                                   form.setValue(
                                     `items.${index}.description`,
-                                    selectedProduct.sale
-                                      ?.description || ""
+                                    selectedProduct.sale?.description || ""
                                   )
                                   form.setValue(
                                     `items.${index}.taxCode`,

--- a/frontend/src/containers/Invoices/CreateInvoiceContainer.tsx
+++ b/frontend/src/containers/Invoices/CreateInvoiceContainer.tsx
@@ -105,6 +105,8 @@ const CreateInvoiceContainer: React.FC = () => {
           amount: "",
         },
       ],
+      paymentDetails:
+        "Please remit payment to:\nANZ Bank\nBSB: 111222\nAccount Number: 987654321\nThank you",
     },
   })
 
@@ -259,6 +261,21 @@ const CreateInvoiceContainer: React.FC = () => {
   }
 
   const addNewRow = () => {
+    // Check if we have at least one row and the last row has an item selected
+    const currentRows = form.getValues("items") || []
+
+    if (currentRows.length > 0) {
+      const lastRow = currentRows[currentRows.length - 1]
+
+      if (!lastRow.item) {
+        // Show error toast if the last row doesn't have an item selected
+        toast.error(
+          "Please select an item for the current row before adding a new one."
+        )
+        return
+      }
+    }
+
     append({
       item: "",
       itemPrice: "",
@@ -336,7 +353,7 @@ const CreateInvoiceContainer: React.FC = () => {
                           }}
                           disabled={isLoadingCustomers}
                         >
-                          <option value="">None</option>
+                          {!field.value && <option value=""> </option>}
                           {customers.map((customer) => (
                             <option key={customer.id} value={customer.name}>
                               {customer.name}
@@ -522,7 +539,7 @@ const CreateInvoiceContainer: React.FC = () => {
                     <thead className="bg-gray-200">
                       <tr>
                         <th className="px-3 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
-                          Item
+                          Item <span className="text-red-500">*</span>
                         </th>
                         <th className="px-3 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
                           Item price
@@ -638,7 +655,9 @@ const CreateInvoiceContainer: React.FC = () => {
                                         }
                                       }}
                                     >
-                                      <option value="">None</option>
+                                      {!field.value && (
+                                        <option value=""> </option>
+                                      )}
                                       {products.map((product) => (
                                         <option
                                           key={product.id}
@@ -726,38 +745,11 @@ const CreateInvoiceContainer: React.FC = () => {
                               render={({ field }) => (
                                 <FormItem>
                                   <FormControl>
-                                    <select
-                                      className="w-24 flex h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                      value={field.value || ""}
-                                      onChange={(e) =>
-                                        field.onChange(e.target.value)
-                                      }
-                                    >
-                                      <option value="">None</option>
-                                      {Array.from(
-                                        new Map(
-                                          products
-                                            .map((p) => p.sale?.taxRate)
-                                            .filter(
-                                              (
-                                                tr
-                                              ): tr is NonNullable<typeof tr> =>
-                                                !!tr?.id
-                                            )
-                                            .map((taxRate) => [
-                                              taxRate.id,
-                                              taxRate,
-                                            ])
-                                        ).values()
-                                      ).map((taxRate) => (
-                                        <option
-                                          key={taxRate.id}
-                                          value={taxRate.name}
-                                        >
-                                          {taxRate.name}
-                                        </option>
-                                      ))}
-                                    </select>
+                                    <Input
+                                      {...field}
+                                      className="w-24"
+                                      readOnly
+                                    />
                                   </FormControl>
                                 </FormItem>
                               )}
@@ -770,7 +762,11 @@ const CreateInvoiceContainer: React.FC = () => {
                               render={({ field }) => (
                                 <FormItem>
                                   <FormControl>
-                                    <Input {...field} className="w-20" />
+                                    <Input
+                                      {...field}
+                                      className="w-20"
+                                      readOnly
+                                    />
                                   </FormControl>
                                 </FormItem>
                               )}

--- a/frontend/src/types/invoice.ts
+++ b/frontend/src/types/invoice.ts
@@ -349,7 +349,7 @@ export const apiToFormSchema = (invoice: Invoice): InvoiceFormValues => {
         description: lineItem?.description || "",
         qty: lineItem?.itemDetails?.quantity?.toString() || "",
         discount: lineItem?.itemDetails?.discountPercent?.toString() || "",
-        taxCode: lineItem?.taxRate?.id || "",
+        taxCode: lineItem?.taxRate?.name || "",
         tax: lineItem?.taxAmount?.toString() || "",
         amount:
           lineItem?.itemDetails?.price && lineItem?.itemDetails?.quantity


### PR DESCRIPTION
1. Fixed a bug caused by modifying tax and taxCode in line items — now these fields are no longer editable.

2. Added a toast notification to prevent adding a new item line if no item is selected.

3. Removed the None option from the item and customer selectors to prevent users from reverting their selection to None.

4. Fixed a bug where the description field was not displaying correctly in edit mode.

5. Fixed a bug where adding a new item in edit mode didn’t correctly populate the qty field.

6. Added default paymentDetails.